### PR TITLE
Tolerate empty header strings in DropboxMetadataHeaderCatcher

### DIFF
--- a/lib/Dropbox/DropboxMetadataHeaderCatcher.php
+++ b/lib/Dropbox/DropboxMetadataHeaderCatcher.php
@@ -48,6 +48,11 @@ final class DropboxMetadataHeaderCatcher
             return strlen($header);
         }
 
+        // Ignore empty headers.
+        if (strlen($header) === 0) {
+            return strlen($header);
+        }
+
         // case-insensitive starts-with check.
         if (\substr_compare($header, "x-dropbox-metadata:", 0, 19, true) !== 0) {
             return strlen($header);


### PR DESCRIPTION
The `substr_compare` call in `DropboxMetadataHeaderCatcher->headerFunction` errors if `$header` is an empty string. I don't know if this would come up in normal usage, however I've been using it with simulated requests in https://github.com/php-vcr/php-vcr which adds an empty header string.

I've [raised the issue with them too](https://github.com/php-vcr/php-vcr/issues/143) but thought there wouldn't be any harm in suggesting this fix too.